### PR TITLE
Restore legacy compatibility: add allocation and risk_guard modules

### DIFF
--- a/services/portfolio-service/allocation.py
+++ b/services/portfolio-service/allocation.py
@@ -1,0 +1,37 @@
+"""Compatibility allocation module used by integration tests."""
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class StrategyStat:
+    name: str
+    sharpe: float
+    drawdown: float
+    regime_fit: float
+
+
+def allocate(stats: Iterable[StrategyStat]) -> dict[str, float]:
+    """Allocate normalized weights based on risk-adjusted score.
+
+    Uses a single pass and avoids temporary list allocations for better throughput
+    when many strategies are evaluated.
+    """
+    entries = tuple(stats)
+    if not entries:
+        return {}
+
+    weights: dict[str, float] = {}
+    total = 0.0
+    for stat in entries:
+        score = max(0.0, stat.sharpe) * (1 - min(0.95, stat.drawdown)) * stat.regime_fit
+        weights[stat.name] = score
+        total += score
+
+    if total <= 0:
+        uniform_weight = 1.0 / len(entries)
+        return {stat.name: uniform_weight for stat in entries}
+
+    inv_total = 1.0 / total
+    return {name: score * inv_total for name, score in weights.items()}

--- a/services/risk-engine/risk_guard.py
+++ b/services/risk-engine/risk_guard.py
@@ -1,0 +1,28 @@
+"""Backward-compatible risk guard helpers for tests and scripts."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RiskLimits:
+    risk_per_trade: float = 0.005
+    daily_loss_limit: float = 0.02
+    max_drawdown: float = 0.10
+    max_exposure: float = 0.25
+
+
+DEFAULT_LIMITS = RiskLimits()
+
+
+def should_halt(
+    daily_loss: float,
+    drawdown: float,
+    exposure: float,
+    limits: RiskLimits | None = None,
+) -> bool:
+    active_limits = limits or DEFAULT_LIMITS
+    return (
+        daily_loss >= active_limits.daily_loss_limit
+        or drawdown >= active_limits.max_drawdown
+        or exposure >= active_limits.max_exposure
+    )


### PR DESCRIPTION
### Motivation
- Tests and legacy scripts expect modules at `services/portfolio-service/allocation.py` and `services/risk-engine/risk_guard.py`, and test collection was failing due to those missing files. 
- Provide small, explicit compatibility shims that restore the previous public API surface without changing core services.
- Improve robustness and minor perf in the allocation helper when evaluating many strategies.

### Description
- Add `services/portfolio-service/allocation.py` with a frozen `StrategyStat` dataclass and an `allocate(stats: Iterable[StrategyStat]) -> dict[str, float]` function that handles empty input, computes non-negative scores in a single pass, and returns normalized weights using an inverse-total multiplier. 
- Add `services/risk-engine/risk_guard.py` with a frozen `RiskLimits` dataclass, a module-level `DEFAULT_LIMITS`, and `should_halt(daily_loss, drawdown, exposure, limits: RiskLimits | None = None) -> bool` to decide trading halts using explicit numeric arguments. 
- Both modules are minimal, backward-compatible helpers intended only to satisfy legacy imports used by tests and scripts.

### Testing
- Ran `pytest -q` after adding the files and all tests passed with `5 passed in 0.27s`. 
- Prior to the additions `pytest` failed during collection with `FileNotFoundError` for the legacy paths, and the new modules remove that error. 
- No other automated test suites were modified or executed in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6670731fc8332b2b2fc9fe753d24a)