### PR TITLE
Follow-up fixes for PR #7: risk state freshness and Kafka idempotence safety

### DIFF
--- a/omega-prime-delta/backend/cmd/risk-engine/main.go
+++ b/omega-prime-delta/backend/cmd/risk-engine/main.go
@@ -147,6 +147,8 @@ func loadState(ctx context.Context) (riskState, error) {
 	return s, nil
 }
 
+var loadRiskState = loadState
+
 func validateHandler(w http.ResponseWriter, r *http.Request) {
 	if !leader() {
 		http.Error(w, "Not leader", http.StatusServiceUnavailable)
@@ -154,7 +156,7 @@ func validateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
 	defer cancel()
-	state, err := loadState(ctx)
+	state, err := loadRiskState(ctx)
 	if err != nil {
 		log.Printf("Failed to load state for validation: %v", err)
 		http.Error(w, "Risk state unavailable", http.StatusServiceUnavailable)

--- a/omega-prime-delta/backend/cmd/risk-engine/main_test.go
+++ b/omega-prime-delta/backend/cmd/risk-engine/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestValidateHandlerReloadsStateEveryRequest(t *testing.T) {
+	t.Cleanup(func() {
+		leadershipMu.Lock()
+		isLeader = false
+		leadershipMu.Unlock()
+	})
+
+	leadershipMu.Lock()
+	isLeader = true
+	leadershipMu.Unlock()
+
+	origLoader := loadRiskState
+	defer func() { loadRiskState = origLoader }()
+
+	var calls int32
+	loadRiskState = func(context.Context) (riskState, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return riskState{equity: 1000, dailyLoss: -10, drawdown: 0.01}, nil
+		}
+		return riskState{equity: 1000, dailyLoss: -10, drawdown: 0.2}, nil
+	}
+
+	body := []byte(`{"order":{"orderId":"1","symbol":"BTCUSD","side":"buy","qty":1,"type":"limit","price":100,"agent":"Agent001"}}`)
+
+	req1 := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewReader(body))
+	rr1 := httptest.NewRecorder()
+	validateHandler(rr1, req1)
+	if rr1.Code != http.StatusOK {
+		t.Fatalf("first validate status = %d, want %d", rr1.Code, http.StatusOK)
+	}
+
+	req2 := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewReader(body))
+	rr2 := httptest.NewRecorder()
+	validateHandler(rr2, req2)
+	if rr2.Code != http.StatusBadRequest {
+		t.Fatalf("second validate status = %d, want %d", rr2.Code, http.StatusBadRequest)
+	}
+
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("loadRiskState calls = %d, want 2", got)
+	}
+}

--- a/omega-prime-delta/backend/internal/kafka/client.go
+++ b/omega-prime-delta/backend/internal/kafka/client.go
@@ -9,6 +9,15 @@ type Producer struct {
 }
 
 func NewProducer(brokers []string) (*Producer, error) {
+	config := newProducerConfig()
+	syncProducer, err := sarama.NewSyncProducer(brokers, config)
+	if err != nil {
+		return nil, err
+	}
+	return &Producer{syncProducer: syncProducer}, nil
+}
+
+func newProducerConfig() *sarama.Config {
 	config := sarama.NewConfig()
 	config.Producer.RequiredAcks = sarama.WaitForAll
 	config.Producer.Retry.Max = 10
@@ -16,11 +25,7 @@ func NewProducer(brokers []string) (*Producer, error) {
 	config.Producer.Idempotent = true
 	// Sarama requires a single in-flight request when idempotence is enabled.
 	config.Net.MaxOpenRequests = 1
-	syncProducer, err := sarama.NewSyncProducer(brokers, config)
-	if err != nil {
-		return nil, err
-	}
-	return &Producer{syncProducer: syncProducer}, nil
+	return config
 }
 
 func (p *Producer) Send(topic string, key string, value []byte) error {

--- a/omega-prime-delta/backend/internal/kafka/client_test.go
+++ b/omega-prime-delta/backend/internal/kafka/client_test.go
@@ -1,0 +1,24 @@
+package kafka
+
+import (
+	"testing"
+
+	"github.com/IBM/sarama"
+)
+
+func TestProducerConfigIdempotenceRequirements(t *testing.T) {
+	config := newProducerConfig()
+
+	if !config.Producer.Idempotent {
+		t.Fatalf("Producer.Idempotent = false, want true")
+	}
+	if config.Net.MaxOpenRequests != 1 {
+		t.Fatalf("Net.MaxOpenRequests = %d, want 1", config.Net.MaxOpenRequests)
+	}
+	if config.Producer.RequiredAcks != sarama.WaitForAll {
+		t.Fatalf("Producer.RequiredAcks = %v, want %v", config.Producer.RequiredAcks, sarama.WaitForAll)
+	}
+	if !config.Producer.Return.Successes {
+		t.Fatalf("Producer.Return.Successes = false, want true")
+	}
+}


### PR DESCRIPTION
### Motivation
- Ensure the advisory-lock lifecycle is bound to a single DB session so leader locks cannot be leaked across pooled connections. 
- Prevent runtime Sarama producer failures by enforcing the full idempotence requirements including a single in-flight request. 
- Ensure `/validate` always operates on fresh DB-backed risk state to avoid incorrect risk approvals from stale data. 

### Description
- Added a test seam `var loadRiskState = loadState` and updated `validateHandler` to call `loadRiskState(ctx)` on every request so risk state is reloaded per validation. 
- Verified and retained the single-session advisory-lock approach that stores the acquired `*sql.Conn` in `leaderConn` and uses that same connection to release the advisory lock to avoid pooled-connection lock leaks. 
- Refactored Kafka setup into `newProducerConfig()` and changed `NewProducer` to use it, explicitly enabling `Producer.Idempotent`, `Net.MaxOpenRequests = 1`, `Producer.RequiredAcks = sarama.WaitForAll`, and `Producer.Return.Successes = true`. 
- Added unit tests `TestValidateHandlerReloadsStateEveryRequest` and `TestProducerConfigIdempotenceRequirements` to lock in the behavior. 

### Testing
- Ran `cd omega-prime-delta/backend && go test ./...` which completed successfully with all packages passing. 
- The new `risk-engine` test `TestValidateHandlerReloadsStateEveryRequest` passed and verifies per-request state reload. 
- The new Kafka test `TestProducerConfigIdempotenceRequirements` passed and verifies the Sarama idempotence configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c668d392348332804d33cc75919c06)