### PR TITLE
Harden risk/execution validation and expand negative-path tests

### DIFF
--- a/VALIDATION_REPORT.md
+++ b/VALIDATION_REPORT.md
@@ -1,0 +1,34 @@
+# Full Validation Report
+
+Date: 2026-04-12 (UTC)
+
+## Scope executed
+- Static syntax validation across backend/research/gateway via `python -m compileall`.
+- Unit and integration smoke tests via `pytest`.
+- Robustness hardening for risk and execution decision logic.
+
+## What was strengthened
+1. **Execution router input validation**
+   - Rejects empty venue candidate lists.
+   - Rejects candidate payloads missing required ranking metrics (`spread`, `liquidity`, `latency_ms`).
+2. **Risk engine state validation**
+   - Rejects `None` state payload early with a clear error.
+   - Normalizes numeric comparisons via explicit `float(...)` conversion for boundary checks.
+3. **Test coverage expansion**
+   - Added negative-path tests for malformed execution candidates.
+   - Added safe-state test to verify non-halt behavior.
+   - Added invalid-state test for risk guard (`None` state).
+
+## Results
+- `ci/scripts/lint.sh` passed.
+- `ci/scripts/test.sh` passed with all tests green.
+
+## Remaining gaps to become “bulletproof”
+- No load/stress tests yet for throughput and latency SLO validation.
+- No formal security scanning (dependency CVE scan, SAST, container scan) in CI.
+- No backtest/evaluation harness here proving live profitability or out-of-sample robustness.
+
+## Recommended next validation additions
+- Add `bandit`, `pip-audit`, and image scanning to CI pipeline.
+- Add chaos/fault-injection tests around Kafka outages and stale market data.
+- Add regression suite for PnL, drawdown, and slippage with fixed historical datasets.

--- a/services/execution_router/app/logic.py
+++ b/services/execution_router/app/logic.py
@@ -1,8 +1,18 @@
 EXCHANGES = ["binance", "kraken", "coinbase", "bybit", "alpaca"]
 
 def select_exchange(candidates):
+    if not candidates:
+        raise ValueError("candidates must contain at least one venue quote")
+
+    required = ("spread", "liquidity", "latency_ms")
+    normalized = []
+    for candidate in candidates:
+        if not all(metric in candidate for metric in required):
+            raise ValueError(f"candidate is missing required metrics: {required}")
+        normalized.append(candidate)
+
     ranked = sorted(
-        candidates,
+        normalized,
         key=lambda x: (x["spread"], -x["liquidity"], x["latency_ms"]),
     )
     return ranked[0]

--- a/services/risk_engine/app/logic.py
+++ b/services/risk_engine/app/logic.py
@@ -6,8 +6,11 @@ RISK_LIMITS = {
 }
 
 def should_halt(state):
+    if state is None:
+        raise ValueError("state is required")
+
     return any([
-        state.get("loss_pct", 0) >= RISK_LIMITS["daily_loss_limit"],
-        state.get("drawdown", 0) >= RISK_LIMITS["max_drawdown"],
-        state.get("exposure", 0) >= RISK_LIMITS["max_exposure"],
+        float(state.get("loss_pct", 0)) >= RISK_LIMITS["daily_loss_limit"],
+        float(state.get("drawdown", 0)) >= RISK_LIMITS["max_drawdown"],
+        float(state.get("exposure", 0)) >= RISK_LIMITS["max_exposure"],
     ])

--- a/tests/test_execution_router.py
+++ b/tests/test_execution_router.py
@@ -6,3 +6,18 @@ def test_exchange_selection_prefers_best_rank():
         {"name": "B", "spread": 1.1, "liquidity": 80, "latency_ms": 15},
     ]
     assert select_exchange(candidates)["name"] == "B"
+
+def test_exchange_selection_rejects_empty_candidates():
+    try:
+        select_exchange([])
+        assert False, "Expected ValueError for empty candidate list"
+    except ValueError as exc:
+        assert "at least one venue quote" in str(exc)
+
+def test_exchange_selection_rejects_incomplete_quote():
+    candidates = [{"name": "A", "spread": 0.8, "latency_ms": 12}]
+    try:
+        select_exchange(candidates)
+        assert False, "Expected ValueError for incomplete quote metrics"
+    except ValueError as exc:
+        assert "missing required metrics" in str(exc)

--- a/tests/test_risk_limits.py
+++ b/tests/test_risk_limits.py
@@ -6,3 +6,13 @@ def test_risk_limits_values():
 
 def test_halt_triggered():
     assert should_halt({"loss_pct": 0.03, "drawdown": 0.0, "exposure": 0.1})
+
+def test_halt_not_triggered_with_safe_state():
+    assert not should_halt({"loss_pct": 0.01, "drawdown": 0.05, "exposure": 0.10})
+
+def test_should_halt_requires_state():
+    try:
+        should_halt(None)
+        assert False, "Expected ValueError when state is None"
+    except ValueError as exc:
+        assert "state is required" in str(exc)


### PR DESCRIPTION
### Motivation
- Prevent runtime surprises by failing fast on malformed execution venue payloads and missing risk state.
- Improve numeric boundary handling in the risk guard to avoid inconsistent comparisons from non-numeric inputs.
- Expand test coverage to include negative and edge paths so validation behavior is explicit and observable.

### Description
- Add input validation to `select_exchange` so it raises a `ValueError` for empty `candidates` and for candidates missing required metrics `("spread", "liquidity", "latency_ms")` before ranking. 
- Harden `should_halt` to raise a `ValueError` when `state` is `None` and normalize metrics with `float(...)` for reliable boundary checks.
- Add negative/edge-path tests in `tests/test_execution_router.py` to assert rejection of empty candidate lists and incomplete quotes. 
- Add tests in `tests/test_risk_limits.py` to assert safe-state non-halt behavior and that `should_halt` requires a non-`None` state, and add `VALIDATION_REPORT.md` documenting the validation scope and remaining gaps.

### Testing
- Ran repository static compile step via `ci/scripts/lint.sh` which completed successfully. 
- Ran unit tests via `ci/scripts/test.sh` where all tests passed (`9 passed` in the run). 
- Added `VALIDATION_REPORT.md` summarizing executed checks and recommended next validation steps (load, security, and backtest/regression additions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db05ce141c83328ef5602ae9c98e75)