### PR TITLE
Add Helm chart, service contracts, protobufs, and CI gates for omega-prime-delta

### DIFF
--- a/omega-prime-delta/.github/workflows/ci.yml
+++ b/omega-prime-delta/.github/workflows/ci.yml
@@ -31,3 +31,28 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           python -c "import main; print('strategy-engine import ok')"
+
+  contract-and-deploy-gates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python for contract validation
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate service contracts
+        working-directory: omega-prime-delta
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml
+          ./scripts/ci/validate_contracts.py
+
+      - name: Validate protobuf definitions
+        working-directory: omega-prime-delta
+        run: ./scripts/ci/validate_protos.sh
+
+      - name: Validate helm chart structure
+        working-directory: omega-prime-delta
+        run: ./scripts/ci/validate_helm.sh

--- a/omega-prime-delta/README.md
+++ b/omega-prime-delta/README.md
@@ -17,6 +17,12 @@ This directory contains the runnable baseline for ΩMEGA Prime Δ across backend
 - **CI guardrail**
   - GitHub Actions workflow and script to fail changes when sentinel placeholders appear in critical bootstrap files.
 
+- **Delivery contracts and deployment packaging**
+  - Helm chart under `infrastructure/helm/omega-prime-delta` for market-ingestion and portfolio-service deployments.
+  - Service contracts in `contracts/service-contracts.yaml` and protobuf definitions in `contracts/proto/omega/prime/delta/v1/`.
+  - CI gate scripts under `scripts/ci/` enforcing contract, protobuf, and Helm chart integrity in pull requests.
+
+
 ## Quick start
 
 1. Export required environment variables for the service you plan to run.

--- a/omega-prime-delta/contracts/proto/omega/prime/delta/v1/risk.proto
+++ b/omega-prime-delta/contracts/proto/omega/prime/delta/v1/risk.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package omega.prime.delta.v1;
+
+option go_package = "github.com/omega-prime-delta/backend/gen/proto/omega/prime/delta/v1;deltav1";
+
+message RiskCheckRequest {
+  string request_id = 1;
+  string order_id = 2;
+  string account_id = 3;
+  string symbol = 4;
+  double notional = 5;
+  double leverage = 6;
+}
+
+message RiskCheckDecision {
+  string request_id = 1;
+  string order_id = 2;
+  bool approved = 3;
+  repeated string reasons = 4;
+  double max_allowed_notional = 5;
+}

--- a/omega-prime-delta/contracts/proto/omega/prime/delta/v1/trading.proto
+++ b/omega-prime-delta/contracts/proto/omega/prime/delta/v1/trading.proto
@@ -1,0 +1,56 @@
+syntax = "proto3";
+
+package omega.prime.delta.v1;
+
+option go_package = "github.com/omega-prime-delta/backend/gen/proto/omega/prime/delta/v1;deltav1";
+
+message MarketTick {
+  string symbol = 1;
+  int64 event_unix_nano = 2;
+  double bid = 3;
+  double ask = 4;
+  double last = 5;
+  double volume = 6;
+}
+
+message OrderIntent {
+  string order_id = 1;
+  string strategy_id = 2;
+  string account_id = 3;
+  string symbol = 4;
+  Side side = 5;
+  OrderType order_type = 6;
+  double quantity = 7;
+  optional double limit_price = 8;
+  optional double stop_price = 9;
+  TimeInForce tif = 10;
+  int64 created_unix_nano = 11;
+}
+
+message ExecutionFill {
+  string order_id = 1;
+  string venue = 2;
+  double filled_qty = 3;
+  double avg_fill_price = 4;
+  int64 fill_unix_nano = 5;
+}
+
+enum Side {
+  SIDE_UNSPECIFIED = 0;
+  SIDE_BUY = 1;
+  SIDE_SELL = 2;
+}
+
+enum OrderType {
+  ORDER_TYPE_UNSPECIFIED = 0;
+  ORDER_TYPE_MARKET = 1;
+  ORDER_TYPE_LIMIT = 2;
+  ORDER_TYPE_STOP = 3;
+}
+
+enum TimeInForce {
+  TIME_IN_FORCE_UNSPECIFIED = 0;
+  TIME_IN_FORCE_DAY = 1;
+  TIME_IN_FORCE_GTC = 2;
+  TIME_IN_FORCE_IOC = 3;
+}

--- a/omega-prime-delta/contracts/service-contracts.yaml
+++ b/omega-prime-delta/contracts/service-contracts.yaml
@@ -1,0 +1,59 @@
+version: 1
+system: omega-prime-delta
+owners:
+  - platform@omega-prime.local
+
+http_contracts:
+  - service: market-ingestion
+    base_path: /v1/market
+    endpoints:
+      - method: GET
+        path: /health
+        response_schema: HealthStatus
+      - method: POST
+        path: /ticks
+        request_schema: MarketTickBatch
+        response_schema: IngestionAck
+  - service: portfolio-service
+    base_path: /v1/portfolio
+    endpoints:
+      - method: GET
+        path: /positions
+        response_schema: PositionList
+      - method: POST
+        path: /rebalance
+        request_schema: RebalanceRequest
+        response_schema: RebalanceResult
+  - service: execution-engine
+    base_path: /v1/execution
+    endpoints:
+      - method: POST
+        path: /orders
+        request_schema: PlaceOrderRequest
+        response_schema: PlaceOrderResponse
+      - method: GET
+        path: /orders/{order_id}
+        response_schema: OrderStatus
+
+kafka_contracts:
+  - topic: omega.market.ticks.v1
+    key: symbol
+    value_schema: omega.prime.delta.v1.MarketTick
+    producers: [market-ingestion]
+    consumers: [strategy-engine, risk-engine]
+  - topic: omega.execution.orders.v1
+    key: order_id
+    value_schema: omega.prime.delta.v1.OrderIntent
+    producers: [strategy-engine]
+    consumers: [execution-engine, risk-engine]
+  - topic: omega.execution.fills.v1
+    key: order_id
+    value_schema: omega.prime.delta.v1.ExecutionFill
+    producers: [execution-engine]
+    consumers: [portfolio-service, capital-allocator]
+
+slos:
+  - name: order_ack_p95
+    objective: "< 150ms"
+  - name: tick_to_signal_p95
+    objective: "< 400ms"

--- a/omega-prime-delta/infrastructure/helm/omega-prime-delta/Chart.yaml
+++ b/omega-prime-delta/infrastructure/helm/omega-prime-delta/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: omega-prime-delta
+description: Helm chart for ΩMEGA Prime Δ core backend services
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+kubeVersion: ">=1.27.0-0"
+keywords:
+  - trading
+  - execution
+  - risk
+home: https://github.com/example/omega-prime-delta
+maintainers:
+  - name: omega-prime-platform

--- a/omega-prime-delta/infrastructure/helm/omega-prime-delta/templates/_helpers.tpl
+++ b/omega-prime-delta/infrastructure/helm/omega-prime-delta/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+{{- define "omega-prime-delta.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "omega-prime-delta.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "omega-prime-delta.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "omega-prime-delta.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "omega-prime-delta.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/omega-prime-delta/infrastructure/helm/omega-prime-delta/templates/deployments.yaml
+++ b/omega-prime-delta/infrastructure/helm/omega-prime-delta/templates/deployments.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.services.marketIngestion.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "omega-prime-delta.fullname" . }}-market-ingestion
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.services.marketIngestion.replicas }}
+  selector:
+    matchLabels:
+      app: market-ingestion
+  template:
+    metadata:
+      labels:
+        app: market-ingestion
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "omega-prime-delta.serviceAccountName" . }}
+      containers:
+        - name: market-ingestion
+          image: "{{ .Values.image.repository }}/market-ingestion:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.services.marketIngestion.containerPort }}
+          env:
+            {{- range $k, $v := .Values.services.marketIngestion.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+---
+{{- end }}
+{{- if .Values.services.portfolioService.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "omega-prime-delta.fullname" . }}-portfolio-service
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.services.portfolioService.replicas }}
+  selector:
+    matchLabels:
+      app: portfolio-service
+  template:
+    metadata:
+      labels:
+        app: portfolio-service
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "omega-prime-delta.serviceAccountName" . }}
+      containers:
+        - name: portfolio-service
+          image: "{{ .Values.image.repository }}/portfolio-service:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.services.portfolioService.containerPort }}
+          env:
+            {{- range $k, $v := .Values.services.portfolioService.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+{{- end }}

--- a/omega-prime-delta/infrastructure/helm/omega-prime-delta/templates/serviceaccount.yaml
+++ b/omega-prime-delta/infrastructure/helm/omega-prime-delta/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "omega-prime-delta.serviceAccountName" . }}
+  namespace: {{ .Values.namespace }}
+{{- end -}}

--- a/omega-prime-delta/infrastructure/helm/omega-prime-delta/templates/services.yaml
+++ b/omega-prime-delta/infrastructure/helm/omega-prime-delta/templates/services.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.services.marketIngestion.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "omega-prime-delta.fullname" . }}-market-ingestion
+  namespace: {{ .Values.namespace }}
+spec:
+  selector:
+    app: market-ingestion
+  ports:
+    - protocol: TCP
+      port: {{ .Values.services.marketIngestion.servicePort }}
+      targetPort: {{ .Values.services.marketIngestion.containerPort }}
+---
+{{- end }}
+{{- if .Values.services.portfolioService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "omega-prime-delta.fullname" . }}-portfolio-service
+  namespace: {{ .Values.namespace }}
+spec:
+  selector:
+    app: portfolio-service
+  ports:
+    - protocol: TCP
+      port: {{ .Values.services.portfolioService.servicePort }}
+      targetPort: {{ .Values.services.portfolioService.containerPort }}
+{{- end }}

--- a/omega-prime-delta/infrastructure/helm/omega-prime-delta/values.yaml
+++ b/omega-prime-delta/infrastructure/helm/omega-prime-delta/values.yaml
@@ -1,0 +1,38 @@
+namespace: omega-prime-delta
+
+image:
+  repository: ghcr.io/omega-prime-delta
+  tag: latest
+  pullPolicy: IfNotPresent
+
+services:
+  marketIngestion:
+    enabled: true
+    replicas: 2
+    containerPort: 8081
+    servicePort: 80
+    env:
+      KAFKA_BROKERS: "kafka:9092"
+      LOG_LEVEL: "info"
+  portfolioService:
+    enabled: true
+    replicas: 2
+    containerPort: 8082
+    servicePort: 80
+    env:
+      REDIS_ADDR: "redis:6379"
+      LOG_LEVEL: "info"
+
+resources:
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+
+serviceAccount:
+  create: true
+  name: ""
+
+podAnnotations: {}

--- a/omega-prime-delta/scripts/ci/validate_contracts.py
+++ b/omega-prime-delta/scripts/ci/validate_contracts.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+CONTRACTS_FILE = ROOT / "contracts" / "service-contracts.yaml"
+
+
+def fail(msg: str) -> None:
+    print(f"[contracts-gate] ERROR: {msg}")
+    sys.exit(1)
+
+
+def main() -> None:
+    if not CONTRACTS_FILE.exists():
+        fail(f"missing file: {CONTRACTS_FILE}")
+
+    with CONTRACTS_FILE.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+
+    for key in ["version", "system", "http_contracts", "kafka_contracts", "slos"]:
+        if key not in data:
+            fail(f"required key '{key}' is missing")
+
+    if not isinstance(data["http_contracts"], list) or not data["http_contracts"]:
+        fail("http_contracts must be a non-empty list")
+
+    if not isinstance(data["kafka_contracts"], list) or not data["kafka_contracts"]:
+        fail("kafka_contracts must be a non-empty list")
+
+    for idx, contract in enumerate(data["http_contracts"]):
+        for key in ["service", "base_path", "endpoints"]:
+            if key not in contract:
+                fail(f"http_contracts[{idx}] missing '{key}'")
+
+    for idx, contract in enumerate(data["kafka_contracts"]):
+        for key in ["topic", "key", "value_schema", "producers", "consumers"]:
+            if key not in contract:
+                fail(f"kafka_contracts[{idx}] missing '{key}'")
+
+    print("[contracts-gate] service contracts validated")
+
+
+if __name__ == "__main__":
+    main()

--- a/omega-prime-delta/scripts/ci/validate_helm.sh
+++ b/omega-prime-delta/scripts/ci/validate_helm.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHART_DIR="$ROOT_DIR/infrastructure/helm/omega-prime-delta"
+
+required=(
+  "$CHART_DIR/Chart.yaml"
+  "$CHART_DIR/values.yaml"
+  "$CHART_DIR/templates/deployments.yaml"
+  "$CHART_DIR/templates/services.yaml"
+)
+
+for file in "${required[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    echo "[helm-gate] ERROR: missing file $file"
+    exit 1
+  fi
+done
+
+grep -q '^apiVersion: v2' "$CHART_DIR/Chart.yaml" || { echo "[helm-gate] ERROR: Chart.yaml must declare apiVersion v2"; exit 1; }
+grep -q '^name: omega-prime-delta' "$CHART_DIR/Chart.yaml" || { echo "[helm-gate] ERROR: Chart.yaml name mismatch"; exit 1; }
+grep -q '^services:' "$CHART_DIR/values.yaml" || { echo "[helm-gate] ERROR: values.yaml must define services"; exit 1; }
+
+echo "[helm-gate] helm chart structure validated"

--- a/omega-prime-delta/scripts/ci/validate_protos.sh
+++ b/omega-prime-delta/scripts/ci/validate_protos.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROTO_DIR="$ROOT_DIR/contracts/proto"
+
+if [[ ! -d "$PROTO_DIR" ]]; then
+  echo "[proto-gate] ERROR: missing directory $PROTO_DIR"
+  exit 1
+fi
+
+shopt -s globstar nullglob
+proto_files=("$PROTO_DIR"/**/*.proto)
+shopt -u globstar nullglob
+
+if [[ ${#proto_files[@]} -eq 0 ]]; then
+  echo "[proto-gate] ERROR: no .proto files found under $PROTO_DIR"
+  exit 1
+fi
+
+for proto in "${proto_files[@]}"; do
+  grep -q '^syntax = "proto3";' "$proto" || { echo "[proto-gate] ERROR: missing proto3 syntax in $proto"; exit 1; }
+  grep -q '^package ' "$proto" || { echo "[proto-gate] ERROR: missing package declaration in $proto"; exit 1; }
+  grep -q '^option go_package ' "$proto" || { echo "[proto-gate] ERROR: missing go_package option in $proto"; exit 1; }
+  echo "[proto-gate] validated $proto"
+done


### PR DESCRIPTION
### Motivation
- Provide delivery packaging and deployment manifests for core delta backend services and make service contracts explicit for downstream consumers. 
- Enforce contract and packaging correctness early by adding CI gates that validate protobufs, Helm chart structure, and service contract presence. 
- Surface machine-readable API/Kafka contracts so runtime teams and CI pipelines can rely on a single source of truth.

### Description
- Add a Helm chart at `omega-prime-delta/infrastructure/helm/omega-prime-delta` including `Chart.yaml`, `values.yaml`, and templates for `deployments`, `services`, and `serviceAccount` plus helper templates. 
- Add repository service contracts at `omega-prime-delta/contracts/service-contracts.yaml` that document HTTP endpoints, Kafka topics, producers/consumers, and SLOs. 
- Add protobuf definitions under `omega-prime-delta/contracts/proto/omega/prime/delta/v1/` for trading (`trading.proto`) and risk (`risk.proto`) messages. 
- Add CI gate scripts under `omega-prime-delta/scripts/ci/` (`validate_helm.sh`, `validate_protos.sh`, `validate_contracts.py`) and extend `omega-prime-delta/.github/workflows/ci.yml` with a `contract-and-deploy-gates` job; update `omega-prime-delta/README.md` to document the additions.

### Testing
- Ran `omega-prime-delta/scripts/ci/validate_helm.sh` and it completed successfully (`[helm-gate] helm chart structure validated`).
- Ran `omega-prime-delta/scripts/ci/validate_protos.sh` and it validated all `.proto` files (`[proto-gate] validated ...`).
- Ran `omega-prime-delta/scripts/ci/validate_contracts.py` after installing `pyyaml` and it returned `[contracts-gate] service contracts validated`.
- Ran backend unit tests with `cd omega-prime-delta/backend && go test ./...` and the tests completed successfully (package tests reported `ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db29649a50833288e2fce3985e6b29)