### PR TITLE
Phase 2: add execution hardening helpers for Go execution core

### DIFF
--- a/omega-prime-delta/backend/internal/execution/errors.go
+++ b/omega-prime-delta/backend/internal/execution/errors.go
@@ -1,0 +1,7 @@
+package execution
+
+import "errors"
+
+var (
+    ErrRiskRejected = errors.New("risk validation failed")
+)

--- a/omega-prime-delta/backend/internal/execution/idempotency.go
+++ b/omega-prime-delta/backend/internal/execution/idempotency.go
@@ -1,0 +1,28 @@
+package execution
+
+import (
+    "context"
+    "time"
+
+    "github.com/go-redis/redis/v8"
+)
+
+type IdempotencyStore struct {
+    rdb *redis.Client
+}
+
+func NewIdempotencyStore() *IdempotencyStore {
+    rdb := redis.NewClient(&redis.Options{
+        Addr: "redis:6379",
+    })
+    return &IdempotencyStore{rdb: rdb}
+}
+
+func (s *IdempotencyStore) TryLock(orderID string) bool {
+    ctx := context.Background()
+    ok, err := s.rdb.SetNX(ctx, "order:"+orderID, "processed", 24*time.Hour).Result()
+    if err != nil {
+        return false
+    }
+    return ok
+}

--- a/omega-prime-delta/backend/internal/execution/risk_gate.go
+++ b/omega-prime-delta/backend/internal/execution/risk_gate.go
@@ -1,0 +1,38 @@
+package execution
+
+import (
+    "bytes"
+    "encoding/json"
+    "net/http"
+    "time"
+
+    "github.com/omega-prime/omega-prime-delta/backend/internal/models"
+)
+
+type RiskGate struct {
+    client *http.Client
+    url    string
+}
+
+func NewRiskGate(riskEngineURL string) *RiskGate {
+    return &RiskGate{
+        client: &http.Client{Timeout: 500 * time.Millisecond},
+        url:    riskEngineURL + "/validate",
+    }
+}
+
+func (g *RiskGate) Validate(order models.Order) error {
+    body, err := json.Marshal(order)
+    if err != nil {
+        return err
+    }
+    resp, err := g.client.Post(g.url, "application/json", bytes.NewReader(body))
+    if err != nil {
+        return err
+    }
+    defer resp.Body.Close()
+    if resp.StatusCode != http.StatusOK {
+        return ErrRiskRejected
+    }
+    return nil
+}


### PR DESCRIPTION
This PR adds the first concrete Phase 2 execution-hardening helpers on top of the PR #9 scaffold base.

Included in this PR:
- `omega-prime-delta/backend/internal/execution/risk_gate.go`
  - synchronous HTTP risk validation helper with fail-closed timeout behavior
- `omega-prime-delta/backend/internal/execution/idempotency.go`
  - Redis-backed idempotency guard using SETNX with 24h TTL
- `omega-prime-delta/backend/internal/execution/errors.go`
  - shared execution error definitions (`ErrRiskRejected`)

Why this PR is intentionally narrow:
- the GitHub connector session could add new files reliably, but could not replace existing scaffold files in place
- the remaining Phase 2 work still needs direct edits to existing files on this branch:
  - `omega-prime-delta/backend/cmd/execution-engine/main.go`
  - `omega-prime-delta/backend/internal/execution/router.go`
  - `omega-prime-delta/backend/internal/brokers/base.go`
  - `omega-prime-delta/backend/internal/models/types.go` (extend only)
  - `omega-prime-delta/frontend/src/hooks/useWebSocket.ts`
  - `omega-prime-delta/infrastructure/docker-compose.yml`
  - `omega-prime-delta/backend/go.mod`

Follow-up local steps after checking out this branch:
1. apply the corrected file replacements for the existing scaffold files
2. add dependencies:
   - `github.com/go-redis/redis/v8 v8.11.5`
   - `github.com/google/uuid v1.6.0`
   - `github.com/segmentio/kafka-go v0.4.47`
3. run `go mod tidy`
4. run the unified compose stack from `omega-prime-delta/infrastructure`
5. verify end-to-end paper-trading flow through `orders.approved -> risk gate -> idempotency -> orders.executed`

This keeps Phase 2 grounded in the verified Go execution path and avoids introducing a parallel execution universe.