### PR TITLE
Harden risk and execution routing validation paths

### DIFF
--- a/services/execution-router/app/logic.py
+++ b/services/execution-router/app/logic.py
@@ -1,8 +1,30 @@
 EXCHANGES = ["binance", "kraken", "coinbase", "bybit", "alpaca"]
 
+
+def _validated_candidate(candidate, required):
+    if not isinstance(candidate, dict):
+        raise TypeError("candidate must be a mapping")
+    if not all(metric in candidate for metric in required):
+        raise ValueError(f"candidate is missing required metrics: {required}")
+
+    normalized = dict(candidate)
+    for metric in required:
+        try:
+            normalized[metric] = float(candidate[metric])
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"candidate[{metric!r}] must be numeric") from exc
+    return normalized
+
+
 def select_exchange(candidates):
+    if not candidates:
+        raise ValueError("candidates must contain at least one venue quote")
+
+    required = ("spread", "liquidity", "latency_ms")
+    normalized = [_validated_candidate(candidate, required) for candidate in candidates]
+
     ranked = sorted(
-        candidates,
+        normalized,
         key=lambda x: (x["spread"], -x["liquidity"], x["latency_ms"]),
     )
     return ranked[0]

--- a/services/execution_router/app/logic.py
+++ b/services/execution_router/app/logic.py
@@ -1,15 +1,27 @@
 EXCHANGES = ["binance", "kraken", "coinbase", "bybit", "alpaca"]
 
+
+def _validated_candidate(candidate, required):
+    if not isinstance(candidate, dict):
+        raise TypeError("candidate must be a mapping")
+    if not all(metric in candidate for metric in required):
+        raise ValueError(f"candidate is missing required metrics: {required}")
+
+    normalized = dict(candidate)
+    for metric in required:
+        try:
+            normalized[metric] = float(candidate[metric])
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"candidate[{metric!r}] must be numeric") from exc
+    return normalized
+
+
 def select_exchange(candidates):
     if not candidates:
         raise ValueError("candidates must contain at least one venue quote")
 
     required = ("spread", "liquidity", "latency_ms")
-    normalized = []
-    for candidate in candidates:
-        if not all(metric in candidate for metric in required):
-            raise ValueError(f"candidate is missing required metrics: {required}")
-        normalized.append(candidate)
+    normalized = [_validated_candidate(candidate, required) for candidate in candidates]
 
     ranked = sorted(
         normalized,

--- a/services/risk-engine/app/logic.py
+++ b/services/risk-engine/app/logic.py
@@ -5,9 +5,25 @@ RISK_LIMITS = {
     "max_exposure": 0.25,
 }
 
+
+def _coerce_metric(state, key):
+    value = state.get(key, 0)
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"state[{key!r}] must be numeric") from exc
+
+
 def should_halt(state):
-    return any([
-        state.get("loss_pct", 0) >= RISK_LIMITS["daily_loss_limit"],
-        state.get("drawdown", 0) >= RISK_LIMITS["max_drawdown"],
-        state.get("exposure", 0) >= RISK_LIMITS["max_exposure"],
-    ])
+    if state is None:
+        raise ValueError("state is required")
+    if not isinstance(state, dict):
+        raise TypeError("state must be a mapping")
+
+    return any(
+        [
+            _coerce_metric(state, "loss_pct") >= RISK_LIMITS["daily_loss_limit"],
+            _coerce_metric(state, "drawdown") >= RISK_LIMITS["max_drawdown"],
+            _coerce_metric(state, "exposure") >= RISK_LIMITS["max_exposure"],
+        ]
+    )

--- a/services/risk_engine/app/logic.py
+++ b/services/risk_engine/app/logic.py
@@ -5,12 +5,25 @@ RISK_LIMITS = {
     "max_exposure": 0.25,
 }
 
+
+def _coerce_metric(state, key):
+    value = state.get(key, 0)
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"state[{key!r}] must be numeric") from exc
+
+
 def should_halt(state):
     if state is None:
         raise ValueError("state is required")
+    if not isinstance(state, dict):
+        raise TypeError("state must be a mapping")
 
-    return any([
-        float(state.get("loss_pct", 0)) >= RISK_LIMITS["daily_loss_limit"],
-        float(state.get("drawdown", 0)) >= RISK_LIMITS["max_drawdown"],
-        float(state.get("exposure", 0)) >= RISK_LIMITS["max_exposure"],
-    ])
+    return any(
+        [
+            _coerce_metric(state, "loss_pct") >= RISK_LIMITS["daily_loss_limit"],
+            _coerce_metric(state, "drawdown") >= RISK_LIMITS["max_drawdown"],
+            _coerce_metric(state, "exposure") >= RISK_LIMITS["max_exposure"],
+        ]
+    )

--- a/tests/test_execution_router.py
+++ b/tests/test_execution_router.py
@@ -1,4 +1,7 @@
+import pytest
+
 from services.execution_router.app.logic import select_exchange
+
 
 def test_exchange_selection_prefers_best_rank():
     candidates = [
@@ -7,17 +10,33 @@ def test_exchange_selection_prefers_best_rank():
     ]
     assert select_exchange(candidates)["name"] == "B"
 
+
 def test_exchange_selection_rejects_empty_candidates():
-    try:
+    with pytest.raises(ValueError, match="at least one venue quote"):
         select_exchange([])
-        assert False, "Expected ValueError for empty candidate list"
-    except ValueError as exc:
-        assert "at least one venue quote" in str(exc)
+
 
 def test_exchange_selection_rejects_incomplete_quote():
     candidates = [{"name": "A", "spread": 0.8, "latency_ms": 12}]
-    try:
+    with pytest.raises(ValueError, match="missing required metrics"):
         select_exchange(candidates)
-        assert False, "Expected ValueError for incomplete quote metrics"
-    except ValueError as exc:
-        assert "missing required metrics" in str(exc)
+
+
+def test_exchange_selection_rejects_non_mapping_candidates():
+    with pytest.raises(TypeError, match="candidate must be a mapping"):
+        select_exchange(["kraken"])
+
+
+def test_exchange_selection_rejects_non_numeric_metrics():
+    with pytest.raises(ValueError, match="must be numeric"):
+        select_exchange([{"spread": "tight", "liquidity": 100, "latency_ms": 12}])
+
+
+def test_exchange_selection_normalizes_numeric_strings():
+    selected = select_exchange(
+        [
+            {"name": "A", "spread": "1.20", "liquidity": "100", "latency_ms": "20"},
+            {"name": "B", "spread": "1.10", "liquidity": "80", "latency_ms": "15"},
+        ]
+    )
+    assert selected["name"] == "B"

--- a/tests/test_risk_limits.py
+++ b/tests/test_risk_limits.py
@@ -1,18 +1,31 @@
+import pytest
+
 from services.risk_engine.app.logic import RISK_LIMITS, should_halt
+
 
 def test_risk_limits_values():
     assert RISK_LIMITS["risk_per_trade"] == 0.005
     assert RISK_LIMITS["daily_loss_limit"] == 0.02
 
+
 def test_halt_triggered():
     assert should_halt({"loss_pct": 0.03, "drawdown": 0.0, "exposure": 0.1})
+
 
 def test_halt_not_triggered_with_safe_state():
     assert not should_halt({"loss_pct": 0.01, "drawdown": 0.05, "exposure": 0.10})
 
+
 def test_should_halt_requires_state():
-    try:
+    with pytest.raises(ValueError, match="state is required"):
         should_halt(None)
-        assert False, "Expected ValueError when state is None"
-    except ValueError as exc:
-        assert "state is required" in str(exc)
+
+
+def test_should_halt_rejects_non_mapping_state():
+    with pytest.raises(TypeError, match="state must be a mapping"):
+        should_halt(["not", "a", "dict"])
+
+
+def test_should_halt_rejects_non_numeric_metrics():
+    with pytest.raises(ValueError, match="must be numeric"):
+        should_halt({"loss_pct": "bad"})


### PR DESCRIPTION
### Motivation
- Prevent crashes and subtle bugs caused by malformed runtime inputs to risk and routing logic. 
- Eliminate divergence between mirrored service paths so both hyphenated and underscore packages behave identically. 
- Provide clearer, actionable errors when callers pass non-mapping or non-numeric payloads. 

### Description
- Added numeric coercion and explicit validation in risk logic by introducing `_coerce_metric` and tightening `should_halt` to reject `None` and non-mapping states and to raise on non-numeric metrics (files: `services/risk_engine/app/logic.py`, `services/risk-engine/app/logic.py`).
- Added candidate validation and normalization to routing logic via `_validated_candidate`, enforcing required metrics, numeric coercion, and type checks in `select_exchange` (files: `services/execution_router/app/logic.py`, `services/execution-router/app/logic.py`).
- Synced the mirrored service directories so both implementations are consistent to avoid future merge/drift issues. 
- Expanded unit tests to cover non-mapping inputs, non-numeric metrics, empty candidate lists, incomplete quotes, and numeric-string normalization (files: `tests/test_risk_limits.py`, `tests/test_execution_router.py`).

### Testing
- Ran the test suite with `pytest -q`. 
- Result: all tests passed: `14 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc55ea9188332852c5983b224ffa2)